### PR TITLE
Retrieve NuGet package metadata from registration leaf when needed

### DIFF
--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -3,6 +3,7 @@ xmonkey-namonica "pkg:generic/openssl@1.1.10g?download_url=https://openssl.org/s
 xmonkey-namonica "pkg:github/package-url/purl-spec@b33dda1cf4515efa8eabbbe8e9b140950805f845" --full
 xmonkey-namonica "pkg:npm/tslib@2.6.2/" --full
 xmonkey-namonica "pkg:nuget/Nirvana.MongoProvider@2.1.154" --full
+xmonkey-namonica "pkg:nuget/AWSSDK.APIGateway@3.7.2.70" --full
 xmonkey-namonica "pkg:pypi/flask@3.0.3/" --full
 xmonkey-namonica "pkg:cargo/grin@1.0.0?type=crate" --full
 xmonkey-namonica "pkg:golang/github.com/mailru/easyjson@v0.7.7" --full

--- a/xmonkey_namonica/handlers/nuget_handler.py
+++ b/xmonkey_namonica/handlers/nuget_handler.py
@@ -65,7 +65,19 @@ class NugetHandler(BaseHandler):
         response = requests.get(url)
         if response.status_code == 200:
             data = response.json()
-            l_vdata = data['items'][-1]['items'][-1]['catalogEntry']
+            reg_page_data = data['items'][-1]
+            reg_data = None
+            if 'items' in reg_page_data:
+                reg_data = reg_page_data
+            else:
+                reg_leaf_url = reg_page_data['@id']
+                response = requests.get(reg_leaf_url)
+                if response.status_code == 200:
+                    reg_data = response.json()
+                else:
+                    logging.error("Can't obtain data from Nuget Registry")
+                    return ''
+            l_vdata = reg_data['items'][-1]['catalogEntry']
             license_expression = l_vdata.get('licenseExpression', '')
             license_url = l_vdata.get('licenseUrl', '')
             if not license_expression:


### PR DESCRIPTION
For some NuGet packages the metadata is not available in the base registration page and must instead be retrieved from a registration leaf page. This change adds logic to retrieve metadata from the right location.