### PR TITLE
Ensure package scope is included in npm package metadata URLs

### DIFF
--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -2,6 +2,7 @@ xmonkey-namonica "pkg:generic/bitwarderl?vcs_url=git%2Bhttps://git.fsfe.org/dxtr
 xmonkey-namonica "pkg:generic/openssl@1.1.10g?download_url=https://openssl.org/source/openssl-1.1.0g.tar.gz&checksum=sha256:de4d501267da" --full
 xmonkey-namonica "pkg:github/package-url/purl-spec@b33dda1cf4515efa8eabbbe8e9b140950805f845" --full
 xmonkey-namonica "pkg:npm/tslib@2.6.2/" --full
+xmonkey-namonica "pkg:npm/@aws-sdk/client-s3@3.51.0" --full
 xmonkey-namonica "pkg:nuget/Nirvana.MongoProvider@2.1.154" --full
 xmonkey-namonica "pkg:pypi/flask@3.0.3/" --full
 xmonkey-namonica "pkg:cargo/grin@1.0.0?type=crate" --full

--- a/xmonkey_namonica/handlers/npm_handler.py
+++ b/xmonkey_namonica/handlers/npm_handler.py
@@ -47,8 +47,7 @@ class NpmHandler(BaseHandler):
         results['license_files'] = files
         copyhits = PackageManager.scan_for_copyright(self.temp_dir)
         results['copyrights'] = copyhits
-        pkg_name = self.purl_details['name']
-        results['license'] = self.get_license(pkg_name)
+        results['license'] = self.get_license()
         results['url'] = self.repo_url
         self.results = results
 
@@ -56,8 +55,8 @@ class NpmHandler(BaseHandler):
         logging.info("Generating report based on the scanned data...")
         return self.results
 
-    def get_license(self, pkg_name):
-        url = f"https://registry.npmjs.org/{pkg_name}"
+    def get_license(self):
+        url = f"https://registry.npmjs.org/{self.get_pkg_name()}"
         response = requests.get(url)
         if response.status_code == 200:
             data = response.json()
@@ -69,14 +68,17 @@ class NpmHandler(BaseHandler):
             return ''
 
     def construct_download_url(self):
-        namespace = (
+        return (
+            f"https://registry.npmjs.org/"
+            f"{self.get_pkg_name()}/-/"
+            f"{self.purl_details['name']}-{self.purl_details['version']}.tgz"
+        )
+
+    def get_pkg_name(self):
+        return (
             self.purl_details['namespace'].replace('%40', '@') + '/' +
             self.purl_details['name']
             if self.purl_details['namespace']
             else self.purl_details['name']
         )
-        return (
-            f"https://registry.npmjs.org/"
-            f"{namespace}/-/"
-            f"{self.purl_details['name']}-{self.purl_details['version']}.tgz"
-        )
+


### PR DESCRIPTION
This change addresses the exclusion of package scope when generating the metadata URL for a npm package.