### PR TITLE
Check out git commit hash when it's included in the purl

### DIFF
--- a/xmonkey_namonica/handlers/gen_handler.py
+++ b/xmonkey_namonica/handlers/gen_handler.py
@@ -128,6 +128,14 @@ class GenericHandler(BaseHandler):
                 stdout=subprocess.DEVNULL,
                 stderr=subprocess.DEVNULL
             )
+            if commit is not None:
+                subprocess.run(
+                    ["git", "checkout", commit],
+                    check=True,
+                    stdout=subprocess.DEVNULL,
+                    stderr=subprocess.DEVNULL,
+                    cwd=self.temp_dir
+                )
             logging.info(f"Repository cloned successfully to {self.temp_dir}")
         except subprocess.CalledProcessError as e:
             print(f"Failed to clone repository: {e}")


### PR DESCRIPTION
I've started onboarding with this tool to generate attribution documents from packages in my project. I noticed that the attribution was wrong for one of the libs, and it was because it wasn't taking into account the git commit hash provided in the purl, which had some different license changes. 

This change just checks out the provided commit if it's included.